### PR TITLE
handle return value of OsFHandleOpenFd() correctly

### DIFF
--- a/File.pm
+++ b/File.pm
@@ -317,8 +317,8 @@ sub OsFHandleOpen {
     if ($@) {
 	return tie *{$fh}, __PACKAGE__, $osfh;
     }
-    return  undef if  $fd < 0;
-    return  open( $fh, $pref."&=".$fd );
+    return  undef unless  $fd;
+    return  open( $fh, $pref."&=".(0+$fd) );
 }
 
 sub GetOsFHandle {


### PR DESCRIPTION
perl's checks for integer supplied to open() for &= became more stringent (and less broken) in perl v5.21.9-204-g22ff313.

Previously, an open like:

  open FH, "<&=123junk"

would attempt to open FD 0, afterwards, such code is treated as an error.

In the OsFHandleOpen() case, when the returned handle is 0, OsFHandleOpen() returns "0 but true" and so calls open like:

  open $fh, "<&=0 but true"

which perl now rejects.

This causes OsFHandleOpen() to fail when the newly allocated FD is 0, causing the failure in https://rt.perl.org/Ticket/Display.html?id=125303