### PR TITLE
Win32API-File: Remove impediment to compiling under C++11

### DIFF
--- a/const2perl.h
+++ b/const2perl.h
@@ -57,7 +57,7 @@ escquote( const char *sValue )
     char *sEscaped= (char *) malloc( lLen );
     char *sNext= sEscaped;
     if(  NULL == sEscaped  ) {
-	fprintf( stderr, "Can't allocate %"UVuf"-byte buffer (errno=%d)\n",
+        fprintf( stderr, "Can't allocate %" UVuf "-byte buffer (errno=%d)\n",
 	  U_V(lLen), _errno );
 	exit( 1 );
     }


### PR DESCRIPTION
C++11 changed from earlier versions to require space between the end of
a string literal and a macro, so that a feature can unambiguously be
added to the language.  Starting in g++ 6.2, the compiler emits a
deprecation warning when there isn't a space (presumably so that future
versions can support C++11).

Although not required by the C++11 change, this patch also makes sure
there is space after a macro call, before a string literal.  This makes
the macro stand out, and is easier to read.

Code and modules included with the Perl core need to be compilable using
C++.  This is so that perl can be embedded in C++ programs. (Actually,
only the hdr files need to be so compilable, but it would be hard to
test that just the hdrs are compilable.)  So we need to accommodate
changes to the C++ language.