### PR TITLE
dont include ppport.h inside core+PERL_NO_GET_CONTEXT

### DIFF
--- a/File.xs
+++ b/File.xs
@@ -1,13 +1,15 @@
 /* Win32API/File.xs */
-
+#define PERL_NO_GET_CONTEXT
 #include "EXTERN.h"
 #include "perl.h"
 #include "XSUB.h"
 /*#include "patchlevel.h"*/
 
 /* Uncomment the next line unless set "WRITE_PERL=>1" in Makefile.PL: */
-#define NEED_newCONSTSUB
-#include "ppport.h"
+#ifdef USE_PPPORT_H
+#  define NEED_newCONSTSUB
+#  include "ppport.h"
+#endif
 
 #ifdef WORD
 # undef WORD
@@ -57,6 +59,7 @@
     static void
     ErrPrintf( const char *sFmt, ... )
     {
+      dTHX;
       va_list pAList;
       static char *sEnv= NULL;
       DWORD uErr= GetLastError();

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,6 +15,7 @@ WriteMakefile1(
     (  $Config{archname} =~ /-object\b/i  ?  ( 'CAPI' => 'TRUE' )  :  ()  ),
     'AUTHOR'		=> 'Tye McQueen <tye@metronet.com>',
     'ABSTRACT_FROM'	=> 'File.pm',
+    'DEFINE'		=> ($ENV{PERL_CORE} ? '' : '-DUSE_PPPORT_H'),
     'postamble' => { IMPORT_LIST => [qw(/._/ !/[a-z]/ :MEDIA_TYPE)],
 		     IFDEF => "!/[a-z\\d]/",
 		     CPLUSPLUS => 1,


### PR DESCRIPTION
-dont include ppport.h if building inside perl core, this allows
 Win32API::File to be removed from mkppport.lst and one day removing the
 mkppport infrastructure
-add PERL_NO_GET_CONTEXT so threaded perl builds of this module are more
 efficient (no Perl_get_context() calls over and over), disk size of
 File.dll 32 bit compiled with VC 2003 went down from 46.5KB to 36.5KB
 by adding PERL_NO_GET_CONTEXT because of much smaller machine code/less
 func calls