### PR TITLE
Use $] instead of $^]

### DIFF
--- a/File.pm
+++ b/File.pm
@@ -332,7 +332,7 @@ sub GetOsFHandle {
 	}
 	no strict "refs";
 	# The eval "" is necessary in Perl 5.6, avoid it otherwise.
-	my $tied = !defined($^]) || $^] < 5.008
+	my $tied = !defined($]) || $] < 5.008
                        ? eval "tied *{$file}"
                        : tied *{$file};
 


### PR DESCRIPTION
Hello,

After investigating rurban/b-keywords#7 and reading the answer to a question I asked to core people at Perl/perl5#20596, it look like `$]` should be used instead of `$^]`  in File.pm.